### PR TITLE
#Fix: the deprecation of initializeClient in NeoForge 1.21.

### DIFF
--- a/src/main/java/kogasastudio/ashihara/fluid/FluidRegistryHandler.java
+++ b/src/main/java/kogasastudio/ashihara/fluid/FluidRegistryHandler.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 public class FluidRegistryHandler
 {
-    private static final ResourceLocation UNDERWATER_LOCATION = ResourceLocation.withDefaultNamespace("textures/misc/underwater.png"),
+    public static final ResourceLocation UNDERWATER_LOCATION = ResourceLocation.withDefaultNamespace("textures/misc/underwater.png"),
             WATER_STILL = ResourceLocation.withDefaultNamespace("block/water_still"),
             WATER_FLOW = ResourceLocation.withDefaultNamespace("block/water_flow"),
             WATER_OVERLAY = ResourceLocation.withDefaultNamespace("block/water_overlay");
@@ -52,70 +52,33 @@ public class FluidRegistryHandler
     public static BaseFlowingFluid.Properties OIL_PROP = getBasicFluidProp(AshiharaFluidTypes.TYPE_OIL, OIL, OIL_FLOWING, BlockRegistryHandler.OIL_BLOCK, ItemRegistryHandler.OIL_BUCKET);
     //oil 168 244 233 132
 
-    public class AshiharaFluidTypes
+    public static class AshiharaFluidTypes
     {
         public static final DeferredRegister<FluidType> TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.FLUID_TYPES, Ashihara.MODID);
 
-        public static final Supplier<FluidType> TYPE_SOY_MILK = TYPES.register
-                (
-                        "soy_milk", () -> createWaterLike("block.ashihara.soy_milk", WATER_STILL, WATER_FLOW, WATER_OVERLAY, UNDERWATER_LOCATION, FastColor.ARGB32.color(255, 255, 253, 225))
-                );
+        public static final Supplier<FluidType> TYPE_SOY_MILK = TYPES.register("soy_milk", () -> createWaterLike("block.ashihara.soy_milk"));
 
-        public static final Supplier<FluidType> TYPE_OIL = TYPES.register
-                (
-                        "oil", () -> createStandard("block.ashihara.oil", 970, 512, false, WATER_STILL, WATER_FLOW, WATER_OVERLAY, UNDERWATER_LOCATION, FastColor.ARGB32.color(255, 246, 223, 12))
-                );
+        public static final Supplier<FluidType> TYPE_OIL = TYPES.register("oil", () -> createStandard("block.ashihara.oil", 970, 512, false));
 
-        private static FluidType createWaterLike(String description, @Nullable ResourceLocation still, @Nullable ResourceLocation flowing, @Nullable ResourceLocation overlay, @Nullable ResourceLocation renderOverlay, int color)
+        private static FluidType createWaterLike(String description)
         {
-            return createStandard(description, 1024, 1024, true, still, flowing, overlay, renderOverlay, color);
+            return createStandard(description, 1024, 1024, true);
         }
 
-        private static FluidType createStandard(String description, int density, int viscosity, boolean canExtinguish, @Nullable ResourceLocation still, @Nullable ResourceLocation flowing, @Nullable ResourceLocation overlay, @Nullable ResourceLocation renderOverlay, int color)
+        private static FluidType createStandard(String description, int density, int viscosity, boolean canExtinguish)
         {
-            return new FluidType
-                (
-                        FluidType.Properties.create()
-                                .descriptionId(description)
-                                .density(density)
-                                .viscosity(viscosity)
-                                .canExtinguish(canExtinguish)
-                                .fallDistanceModifier(0f)
-                                .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
-                                .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY)
-                                .sound(SoundActions.FLUID_VAPORIZE, SoundEvents.FIRE_EXTINGUISH)
-                                .canHydrate(false)
-                                .supportsBoating(true)
-                )
-            {
-                @Override
-                public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer)
-                {
-                    consumer.accept
-                    (
-                        new IClientFluidTypeExtensions()
-                        {
-                            @Override
-                            public int getTintColor() {return color;}
-
-                            @Override
-                            public ResourceLocation getStillTexture() {return still == null ? IClientFluidTypeExtensions.super.getStillTexture() : still;}
-
-                            @Override
-                            public ResourceLocation getFlowingTexture() {return flowing == null ? IClientFluidTypeExtensions.super.getFlowingTexture() : flowing;}
-
-                            @Override
-                            public @Nullable ResourceLocation getOverlayTexture() {return overlay == null ? IClientFluidTypeExtensions.super.getOverlayTexture() : overlay;}
-
-                            @Override
-                            public @Nullable ResourceLocation getRenderOverlayTexture(Minecraft mc)
-                            {
-                                return renderOverlay == null ? IClientFluidTypeExtensions.super.getRenderOverlayTexture(mc) : renderOverlay;
-                            }
-                        }
-                    );
-                }
-            };
+            return new FluidType(
+                    FluidType.Properties.create()
+                            .descriptionId(description)
+                            .density(density)
+                            .viscosity(viscosity)
+                            .canExtinguish(canExtinguish)
+                            .fallDistanceModifier(0f)
+                            .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
+                            .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY)
+                            .sound(SoundActions.FLUID_VAPORIZE, SoundEvents.FIRE_EXTINGUISH)
+                            .canHydrate(false)
+                            .supportsBoating(true));
         }
     }
 }

--- a/src/main/java/kogasastudio/ashihara/item/ItemSujikaButo.java
+++ b/src/main/java/kogasastudio/ashihara/item/ItemSujikaButo.java
@@ -1,21 +1,14 @@
 package kogasastudio.ashihara.item;
 
 import kogasastudio.ashihara.Ashihara;
-import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
-import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Consumer;
 
 public class ItemSujikaButo extends ArmorItem
 {
@@ -26,34 +19,9 @@ public class ItemSujikaButo extends ArmorItem
         super(ArmorMaterials.NETHERITE, Type.HELMET, new Properties());
     }
 
-    // todo 这个方法没了？
-    //@Override
-    //@OnlyIn(Dist.CLIENT)
-    //@SuppressWarnings("unchecked")
-    //public <A extends HumanoidModel<?>> A getArmorModel(LivingEntity entityLiving, ItemStack itemStack, EquipmentSlot armorSlot, A _default) {
-    //    return (A) new SujikabutoModel(0.8F);
-    //}
-
-    @Override
-    public void initializeClient(Consumer<IClientItemExtensions> consumer)
-    {
-        consumer.accept(new KabutoItemExtensions());
-        super.initializeClient(consumer);
-    }
-
     @Override
     public @Nullable ResourceLocation getArmorTexture(ItemStack stack, Entity entity, EquipmentSlot slot, ArmorMaterial.Layer layer, boolean innerModel)
     {
         return TEXTURE;
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    public static class KabutoItemExtensions implements IClientItemExtensions
-    {
-        @Override
-        public HumanoidModel<?> getHumanoidArmorModel(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot equipmentSlot, HumanoidModel<?> original)
-        {
-            return IClientItemExtensions.super.getHumanoidArmorModel(livingEntity, itemStack, equipmentSlot, original);
-        }
     }
 }

--- a/src/main/java/kogasastudio/ashihara/item/block/ItemBlockPail.java
+++ b/src/main/java/kogasastudio/ashihara/item/block/ItemBlockPail.java
@@ -29,19 +29,6 @@ public class ItemBlockPail extends BlockItem
     }
 
     @Override
-    public void initializeClient(Consumer<IClientItemExtensions> consumer)
-    {
-        consumer.accept(new IClientItemExtensions()
-        {
-            @Override
-            public BlockEntityWithoutLevelRenderer getCustomRenderer()
-            {
-                return new PailISTER(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
-            }
-        });
-    }
-
-    @Override
     public void appendHoverText(ItemStack stack, TooltipContext pContext, List<Component> tooltip, TooltipFlag flagIn)
     {
         super.appendHoverText(stack, pContext, tooltip, flagIn);


### PR DESCRIPTION
`Item#initializeClient`, `Block#initializeClient`, `FluidType#initializeClient` were marked as deprecated and for removal in NeoForge 1.21.  
I have migrated it to RegisterClientExtensionsEvent according to the javadoc.  